### PR TITLE
Fix command line tools checking.

### DIFF
--- a/cider/core.py
+++ b/cider/core.py
@@ -157,7 +157,7 @@ class Cider(object):
         developer_dir = spawn(["/usr/bin/xcode-select", "-print-path"],
                               check_output=True,
                               debug=self.debug,
-                              env=self.env)
+                              env=self.env).strip()
 
         return bool(os.path.isdir(developer_dir) and os.path.exists(
             os.path.join(developer_dir, "usr", "bin", "git")


### PR DESCRIPTION
In v1.1.4, cider always attempt to install command line tool, but it has already been installed.

``` bash
% cider restore
==> Installing the Command Line Tools (expect a GUI popup):
xcode-select: error: command line tools are already installed, use "Software Update" to install updates
Whoops! `/usr/bin/xcode-select --install` failed with code 1
```

In my environment(Python2.7.8), 
`spawn(["/usr/bin/xcode-select", "-print-path"],
                              check_output=True,
                              debug=self.debug,
                              env=self.env)` returns string with newline(`'/Applications/Xcode.app/Contents/Developer\n'`) and `os.path.isdir` returns False with newline:

``` bash
>>> os.path.isdir('/Applications/Xcode.app/Contents/Developer\n')
False
```
