### PR TITLE
Modify dependency specifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'Click>=3.3',
+        'Click>=3.3,<5.0',
         'rfc3987>=1.3.4',
         'PyYAML>=3.11'
     ],


### PR DESCRIPTION
Using cider with `click>=5.0` will throw an exception.

```sh
~ % cider restore
/Users/keitaoouchi/.pyenv/versions/2.7.10/lib/python2.7/site-packages/cider/_cli.py:72: Warning: Click detected the use of the unicode_literals __future__ import.  This is heavily discouraged because it can introduce subtle bugs in your code.  You should instead use explicit u"" literals for your unicode strings.  For more information see http://click.pocoo.org/python3/
  @click.pass_context
/Users/keitaoouchi/.pyenv/versions/2.7.10/lib/python2.7/site-packages/cider/_cli.py:82: Warning: Click detected the use of the unicode_literals __future__ import.  This is heavily discouraged because it can introduce subtle bugs in your code.  You should instead use explicit u"" literals for your unicode strings.  For more information see http://click.pocoo.org/python3/
  def cask(ctx, command, args, force=None):
/Users/keitaoouchi/.pyenv/versions/2.7.10/lib/python2.7/site-packages/cider/_cli.py:111: Warning: Click detected the use of the unicode_literals __future__ import.  This is heavily discouraged because it can introduce subtle bugs in your code.  You should instead use explicit u"" literals for your unicode strings.  For more information see http://click.pocoo.org/python3/
  @click.option("-i", "--ignore-errors", is_flag=True)
/Users/keitaoouchi/.pyenv/versions/2.7.10/lib/python2.7/site-packages/cider/_cli.py:120: Warning: Click detected the use of the unicode_literals __future__ import.  This is heavily discouraged because it can introduce subtle bugs in your code.  You should instead use explicit u"" literals for your unicode strings.  For more information see http://click.pocoo.org/python3/
  def install(cider, formulas, force=None):
/Users/keitaoouchi/.pyenv/versions/2.7.10/lib/python2.7/site-packages/cider/_cli.py:126: Warning: Click detected the use of the unicode_literals __future__ import.  This is heavily discouraged because it can introduce subtle bugs in your code.  You should instead use explicit u"" literals for your unicode strings.  For more information see http://click.pocoo.org/python3/
  @click.pass_obj
/Users/keitaoouchi/.pyenv/versions/2.7.10/lib/python2.7/site-packages/cider/_cli.py:133: Warning: Click detected the use of the unicode_literals __future__ import.  This is heavily discouraged because it can introduce subtle bugs in your code.  You should instead use explicit u"" literals for your unicode strings.  For more information see http://click.pocoo.org/python3/
  @click.pass_obj
/Users/keitaoouchi/.pyenv/versions/2.7.10/lib/python2.7/site-packages/cider/_cli.py:143: Warning: Click detected the use of the unicode_literals __future__ import.  This is heavily discouraged because it can introduce subtle bugs in your code.  You should instead use explicit u"" literals for your unicode strings.  For more information see http://click.pocoo.org/python3/
  @click.pass_obj
/Users/keitaoouchi/.pyenv/versions/2.7.10/lib/python2.7/site-packages/cider/_cli.py:151: Warning: Click detected the use of the unicode_literals __future__ import.  This is heavily discouraged because it can introduce subtle bugs in your code.  You should instead use explicit u"" literals for your unicode strings.  For more information see http://click.pocoo.org/python3/
  def relink(cider, force=None):
/Users/keitaoouchi/.pyenv/versions/2.7.10/lib/python2.7/site-packages/cider/_cli.py:157: Warning: Click detected the use of the unicode_literals __future__ import.  This is heavily discouraged because it can introduce subtle bugs in your code.  You should instead use explicit u"" literals for your unicode strings.  For more information see http://click.pocoo.org/python3/
  @click.pass_obj
/Users/keitaoouchi/.pyenv/versions/2.7.10/lib/python2.7/site-packages/cider/_cli.py:163: Warning: Click detected the use of the unicode_literals __future__ import.  This is heavily discouraged because it can introduce subtle bugs in your code.  You should instead use explicit u"" literals for your unicode strings.  For more information see http://click.pocoo.org/python3/
  @click.pass_obj
/Users/keitaoouchi/.pyenv/versions/2.7.10/lib/python2.7/site-packages/cider/_cli.py:179: Warning: Click detected the use of the unicode_literals __future__ import.  This is heavily discouraged because it can introduce subtle bugs in your code.  You should instead use explicit u"" literals for your unicode strings.  For more information see http://click.pocoo.org/python3/
  def set_default(cider, name, key, value, globaldomain=None, force=None):
/Users/keitaoouchi/.pyenv/versions/2.7.10/lib/python2.7/site-packages/cider/_cli.py:195: Warning: Click detected the use of the unicode_literals __future__ import.  This is heavily discouraged because it can introduce subtle bugs in your code.  You should instead use explicit u"" literals for your unicode strings.  For more information see http://click.pocoo.org/python3/
  def remove_default(cider, name, key, globaldomain=None):
/Users/keitaoouchi/.pyenv/versions/2.7.10/lib/python2.7/site-packages/cider/_cli.py:202: Warning: Click detected the use of the unicode_literals __future__ import.  This is heavily discouraged because it can introduce subtle bugs in your code.  You should instead use explicit u"" literals for your unicode strings.  For more information see http://click.pocoo.org/python3/
  @click.pass_obj
/Users/keitaoouchi/.pyenv/versions/2.7.10/lib/python2.7/site-packages/cider/_cli.py:210: Warning: Click detected the use of the unicode_literals __future__ import.  This is heavily discouraged because it can introduce subtle bugs in your code.  You should instead use explicit u"" literals for your unicode strings.  For more information see http://click.pocoo.org/python3/
  @click.pass_obj
/Users/keitaoouchi/.pyenv/versions/2.7.10/lib/python2.7/site-packages/cider/_cli.py:217: Warning: Click detected the use of the unicode_literals __future__ import.  This is heavily discouraged because it can introduce subtle bugs in your code.  You should instead use explicit u"" literals for your unicode strings.  For more information see http://click.pocoo.org/python3/
  @click.pass_obj
/Users/keitaoouchi/.pyenv/versions/2.7.10/lib/python2.7/site-packages/cider/_cli.py:223: Warning: Click detected the use of the unicode_literals __future__ import.  This is heavily discouraged because it can introduce subtle bugs in your code.  You should instead use explicit u"" literals for your unicode strings.  For more information see http://click.pocoo.org/python3/
  @click.pass_obj
/Users/keitaoouchi/.pyenv/versions/2.7.10/lib/python2.7/site-packages/cider/_cli.py:229: Warning: Click detected the use of the unicode_literals __future__ import.  This is heavily discouraged because it can introduce subtle bugs in your code.  You should instead use explicit u"" literals for your unicode strings.  For more information see http://click.pocoo.org/python3/
  @click.pass_obj
/Users/keitaoouchi/.pyenv/versions/2.7.10/lib/python2.7/site-packages/cider/_cli.py:237: Warning: Click detected the use of the unicode_literals __future__ import.  This is heavily discouraged because it can introduce subtle bugs in your code.  You should instead use explicit u"" literals for your unicode strings.  For more information see http://click.pocoo.org/python3/
  @click.pass_obj
/Users/keitaoouchi/.pyenv/versions/2.7.10/lib/python2.7/site-packages/cider/_cli.py:244: Warning: Click detected the use of the unicode_literals __future__ import.  This is heavily discouraged because it can introduce subtle bugs in your code.  You should instead use explicit u"" literals for your unicode strings.  For more information see http://click.pocoo.org/python3/
  @click.pass_obj
/Users/keitaoouchi/.pyenv/versions/2.7.10/lib/python2.7/site-packages/cider/_cli.py:251: Warning: Click detected the use of the unicode_literals __future__ import.  This is heavily discouraged because it can introduce subtle bugs in your code.  You should instead use explicit u"" literals for your unicode strings.  For more information see http://click.pocoo.org/python3/
  cli.main(standalone_mode=False)
Traceback (most recent call last):
  File "/Users/keitaoouchi/.pyenv/versions/2.7.10/bin/cider", line 9, in <module>
    load_entry_point('cider==1.1.6', 'console_scripts', 'cider')()
  File "/Users/keitaoouchi/.pyenv/versions/2.7.10/lib/python2.7/site-packages/cider/_cli.py", line 251, in main
    cli.main(standalone_mode=False)
  File "/Users/keitaoouchi/.pyenv/versions/2.7.10/lib/python2.7/site-packages/click/core.py", line 680, in main
    rv = self.invoke(ctx)
  File "/Users/keitaoouchi/.pyenv/versions/2.7.10/lib/python2.7/site-packages/click/core.py", line 1027, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/keitaoouchi/.pyenv/versions/2.7.10/lib/python2.7/site-packages/click/core.py", line 873, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/keitaoouchi/.pyenv/versions/2.7.10/lib/python2.7/site-packages/click/core.py", line 508, in invoke
    return callback(*args, **kwargs)
  File "/Users/keitaoouchi/.pyenv/versions/2.7.10/lib/python2.7/site-packages/click/decorators.py", line 16, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/keitaoouchi/.pyenv/versions/2.7.10/lib/python2.7/site-packages/click/decorators.py", line 27, in new_func
    return f(get_current_context().obj, *args, **kwargs)
TypeError: restore() got multiple values for keyword argument 'ignore_errors'
```

Downgrading `click==4.1` fixed the problem.