### PR TITLE
Fix for defaults.write

### DIFF
--- a/cider/_sh.py
+++ b/cider/_sh.py
@@ -127,7 +127,7 @@ class Defaults(object):
         }
 
         return next(
-            (k for t, k in key_types.items() if isinstance(value, t)),
+            (k for t, k in sorted(key_types.items()) if isinstance(value, t)),
             "-string"
         )
 


### PR DESCRIPTION
The key_type dictionary was iterated over with no order. This causes a
boolean and possibly other values to be identified as other types such as `int`
should python match it first within the `isinstance()` return check.

To correct this, the `sorted()` function was added to respect the order.

This also should fix #34.
