### PR TITLE
Fix Python3 compatibility issue in apply_defaults

### DIFF
--- a/cider/_sh.py
+++ b/cider/_sh.py
@@ -120,14 +120,14 @@ class Defaults(object):
 
     @staticmethod
     def key_type(value):
-        key_types = {
-            bool: "-bool",
-            float: "-float",
-            int: "-int"
-        }
+        key_types = [
+            (bool, "-bool"),
+            (float, "-float"),
+            (int, "-int")
+        ]
 
         return next(
-            (k for t, k in sorted(key_types.items()) if isinstance(value, t)),
+            (k for t, k in key_types if isinstance(value, t)),
             "-string"
         )
 


### PR DESCRIPTION
```python
sorted(key_types.items())
````

won’t work on python 3 as types are not
orderable. Is there a particular reason you don’t simply use

```python
return key_types.get(type(value), "-string")
```
?